### PR TITLE
Add authentication utilities and secure book endpoints

### DIFF
--- a/backend/app/routers/books.py
+++ b/backend/app/routers/books.py
@@ -2,13 +2,19 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session, select
 
 from ..db import get_session
-from ..models import Book
+from ..models import Book, User
+from ..security import get_current_user
 
 router = APIRouter(prefix="/books", tags=["books"])
 
 
 @router.post("/", response_model=Book)
-def create_book(book: Book, session: Session = Depends(get_session)):
+def create_book(
+    book: Book,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    book.owner_id = current_user.id
     session.add(book)
     session.commit()
     session.refresh(book)
@@ -16,13 +22,20 @@ def create_book(book: Book, session: Session = Depends(get_session)):
 
 
 @router.get("/", response_model=list[Book])
-def read_books(session: Session = Depends(get_session)):
-    return session.exec(select(Book)).all()
+def read_books(
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    return session.exec(select(Book).where(Book.owner_id == current_user.id)).all()
 
 
 @router.get("/{book_id}", response_model=Book)
-def read_book(book_id: int, session: Session = Depends(get_session)):
+def read_book(
+    book_id: int,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
     book = session.get(Book, book_id)
-    if not book:
+    if not book or book.owner_id != current_user.id:
         raise HTTPException(status_code=404, detail="Book not found")
     return book

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -1,0 +1,51 @@
+from datetime import datetime, timedelta
+from typing import Optional
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from sqlmodel import Session
+
+from .db import get_session
+from .models import User
+
+SECRET_KEY = "secret-key"
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/users/login")
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+def get_current_user(
+    token: str = Depends(oauth2_scheme),
+    session: Session = Depends(get_session),
+) -> User:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        user_id: Optional[str] = payload.get("sub")
+        if user_id is None:
+            raise credentials_exception
+    except JWTError:
+        raise credentials_exception
+    user = session.get(User, int(user_id))
+    if user is None:
+        raise credentials_exception
+    return user

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,5 @@ ebooklib
 pydantic
 sqlmodel
 alembic
+passlib[bcrypt]
+python-jose

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,51 @@
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, create_engine, Session
+
+from backend.app.main import app
+from backend.app.db import get_session
+
+# Setup in-memory test database
+test_engine = create_engine("sqlite://", connect_args={"check_same_thread": False})
+SQLModel.metadata.create_all(test_engine)
+
+
+def get_session_override():
+    with Session(test_engine) as session:
+        yield session
+
+
+app.dependency_overrides[get_session] = get_session_override
+client = TestClient(app)
+
+
+def test_registration_login_and_protected_routes():
+    # Register user
+    resp = client.post("/users/register", json={"email": "user@example.com", "password": "secret"})
+    assert resp.status_code == 200
+    token = resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # Login user
+    login_resp = client.post("/users/login", json={"email": "user@example.com", "password": "secret"})
+    assert login_resp.status_code == 200
+    login_token = login_resp.json()["access_token"]
+    auth_headers = {"Authorization": f"Bearer {login_token}"}
+
+    # Unauthorized access
+    assert client.get("/books").status_code == 401
+
+    # Create book with auth
+    book_resp = client.post("/books", json={"title": "Test Book"}, headers=auth_headers)
+    assert book_resp.status_code == 200
+    book = book_resp.json()
+    assert book["owner_id"] == 1
+
+    # Retrieve books with auth
+    books_resp = client.get("/books", headers=auth_headers)
+    assert books_resp.status_code == 200
+    books = books_resp.json()
+    assert len(books) == 1
+    assert books[0]["title"] == "Test Book"
+
+    # Unauthorized book creation
+    assert client.post("/books", json={"title": "Bad"}).status_code == 401


### PR DESCRIPTION
## Summary
- Add password hashing and JWT helpers in `security.py`
- Implement user registration and login issuing JWTs
- Protect book routes with token validation and ownership checks
- Cover auth flows with new tests

## Testing
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement python-jose)*
- `pip install 'passlib[bcrypt]'` *(fails: No matching distribution found for passlib[bcrypt])* 
- `pip install httpx` *(fails: No matching distribution found for httpx)*
- `pytest backend/tests/test_auth.py -q` *(fails: RuntimeError: The starlette.testclient module requires the httpx package to be installed.)*

------
https://chatgpt.com/codex/tasks/task_e_68a5fb6bbfc0832fb50aa2d9fb78d011