### PR TITLE
feat: add environment settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example environment configuration
+DATABASE_URL=sqlite:///./app.db
+JWT_SECRET=change-me
+JWT_ALGORITHM=HS256
+APP_NAME=Cinematic Reading Engine

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__/
 .pytest_cache/
 client/node_modules/
+.env
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,16 @@
+from pydantic import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Application configuration loaded from environment variables."""
+
+    database_url: str = "sqlite:///./app.db"
+    jwt_secret: str = "change-me"
+    jwt_algorithm: str = "HS256"
+    app_name: str = "Cinematic Reading Engine"
+
+    class Config:
+        env_file = ".env"
+
+
+settings = Settings()

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,12 +1,13 @@
 from sqlmodel import SQLModel, create_engine, Session
 from typing import Generator
 
-# SQLite URL for local development
-DATABASE_URL = "sqlite:///./app.db"
+from .config import settings
+
+# Database engine configured via settings.database_url
 
 # Needed for SQLite to allow usage from different threads
 connect_args = {"check_same_thread": False}
-engine = create_engine(DATABASE_URL, echo=True, connect_args=connect_args)
+engine = create_engine(settings.database_url, echo=True, connect_args=connect_args)
 
 def get_session() -> Generator[Session, None, None]:
     with Session(engine) as session:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,10 @@
 from fastapi import FastAPI
 
+from .config import settings
 from .db import init_db
 from .routers import books, users
 
-app = FastAPI(title="Cinematic Reading Engine")
+app = FastAPI(title=settings.app_name)
 
 
 @app.on_event("startup")


### PR DESCRIPTION
## Summary
- load environment variables using pydantic `Settings`
- use `settings` for database engine and app title
- document required env vars and ignore local `.env`

## Testing
- `pytest backend`

------
https://chatgpt.com/codex/tasks/task_e_68a5fc8e3664832f80451784eb98ee1d