### PR TITLE
Add backend tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt
+          pip install pytest
+      - name: Compile
+        run: python -m py_compile $(git ls-files '*.py')
+      - name: Test
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Cinematic Reading Engine
 
+[![CI](https://github.com/OWNER/Storyboard/actions/workflows/ci.yml/badge.svg)](https://github.com/OWNER/Storyboard/actions/workflows/ci.yml)
+
 This repository contains the early scaffolding for **Cinei-read**, an MVP
 that enhances traditional ebooks with subtle cinematic effects.
 
@@ -22,3 +24,14 @@ migrations. Typical commands run from the `backend` directory:
 alembic revision --autogenerate -m "description"  # create a new migration
 alembic upgrade head                                # apply migrations
 ```
+
+## Testing
+
+Run the test suite and verify Python syntax with:
+
+```bash
+pytest
+python -m py_compile $(git ls-files '*.py')
+```
+
+The CI workflow executes these commands on every push.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ ebooklib
 pydantic
 sqlmodel
 alembic
+httpx

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,24 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, Session, create_engine
+
+from backend.app.main import app
+from backend.app.db import get_session
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+
+
+@pytest.fixture(name="client")
+def client_fixture(session):
+    def get_session_override():
+        return session
+    app.dependency_overrides[get_session] = get_session_override
+    with TestClient(app) as client:
+        yield client
+    app.dependency_overrides.clear()

--- a/backend/tests/test_books.py
+++ b/backend/tests/test_books.py
@@ -1,0 +1,22 @@
+
+def test_create_and_read_book(client):
+    user_resp = client.post("/users/", json={"email": "b@example.com", "password": "secret"})
+    user_id = user_resp.json()["id"]
+
+    response = client.post("/books/", json={"title": "Book", "owner_id": user_id})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["title"] == "Book"
+    assert data["owner_id"] == user_id
+    book_id = data["id"]
+
+    get_resp = client.get(f"/books/{book_id}")
+    assert get_resp.status_code == 200
+    fetched = get_resp.json()
+    assert fetched["title"] == "Book"
+    assert fetched["owner_id"] == user_id
+
+    list_resp = client.get("/books/")
+    assert list_resp.status_code == 200
+    books = list_resp.json()
+    assert any(b["id"] == book_id for b in books)

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -1,0 +1,21 @@
+from backend.app.models import User
+
+
+def test_create_and_read_user(client):
+    response = client.post("/users/", json={"email": "a@example.com", "password": "secret"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["email"] == "a@example.com"
+    assert "id" in data
+
+    user_id = data["id"]
+    get_resp = client.get(f"/users/{user_id}")
+    assert get_resp.status_code == 200
+    fetched = get_resp.json()
+    assert fetched["id"] == user_id
+    assert fetched["email"] == "a@example.com"
+
+    list_resp = client.get("/users/")
+    assert list_resp.status_code == 200
+    users = list_resp.json()
+    assert any(u["id"] == user_id for u in users)


### PR DESCRIPTION
## Summary
- add in-memory database fixtures and tests for user/book routes
- introduce GitHub Actions workflow to run pytest and py_compile
- document test commands and CI badge in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68a5fc908324832f839a077740babd14