### PR TITLE
test: add health check test

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,11 @@ migrations. Typical commands run from the `backend` directory:
 alembic revision --autogenerate -m "description"  # create a new migration
 alembic upgrade head                                # apply migrations
 ```
+
+## Testing
+
+Run the backend test suite with [pytest](https://docs.pytest.org/):
+
+```bash
+pytest
+```

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,0 +1,11 @@
+from fastapi.testclient import TestClient
+
+from backend.app.main import app
+
+client = TestClient(app)
+
+
+def test_root_endpoint():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = backend/tests


### PR DESCRIPTION
## Summary
- add TestClient coverage for the root health check
- set pytest to collect backend tests
- document how to run backend tests

## Testing
- `pytest` *(fails: RuntimeError requiring httpx; installation blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a602e177e8832f86d7ba41239d2654