### PR TITLE
Use EmailStr and hashed passwords in user model

### DIFF
--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from typing import List, Optional
 
+from pydantic import EmailStr
 from sqlmodel import Field, Relationship, SQLModel
 
 
@@ -8,7 +9,7 @@ class User(SQLModel, table=True):
     """Database model for application users."""
 
     id: Optional[int] = Field(default=None, primary_key=True)
-    email: str = Field(index=True)
-    password: str
+    email: EmailStr = Field(index=True)
+    hashed_password: str = Field(..., min_length=1)
 
     books: List["Book"] = Relationship(back_populates="owner")

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -29,7 +29,7 @@ def register(user: UserCreate, session: Session = Depends(get_session)):
     existing = session.exec(select(User).where(User.email == user.email)).first()
     if existing:
         raise HTTPException(status_code=400, detail="Email already registered")
-    db_user = User(email=user.email, password=get_password_hash(user.password))
+    db_user = User(email=user.email, hashed_password=get_password_hash(user.password))
     session.add(db_user)
     session.commit()
     session.refresh(db_user)
@@ -40,7 +40,7 @@ def register(user: UserCreate, session: Session = Depends(get_session)):
 @router.post("/login", response_model=Token)
 def login(user: UserLogin, session: Session = Depends(get_session)):
     db_user = session.exec(select(User).where(User.email == user.email)).first()
-    if not db_user or not verify_password(user.password, db_user.password):
+    if not db_user or not verify_password(user.password, db_user.hashed_password):
         raise HTTPException(status_code=400, detail="Incorrect email or password")
     token = create_access_token({"sub": str(db_user.id)})
     return Token(access_token=token)


### PR DESCRIPTION
## Summary
- use `EmailStr` type for user emails
- require `hashed_password` field with min length and update user endpoints

## Testing
- `pytest backend/tests/test_auth.py` *(fails: The starlette.testclient module requires the httpx package to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a602e06dc8832f91c03bee6db44690