### PR TITLE
chore: expand .gitignore for Python and React Native

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,15 @@
+# Python
 __pycache__/
+*.pyc
 .pytest_cache/
-client/node_modules/
+.venv/
 .env
+dist/
+build/
 
+# React Native
+client/node_modules/
+android/
+ios/
+npm-debug.log
+yarn-error.log


### PR DESCRIPTION
## Summary
- ignore Python build artifacts and environments
- add React Native directories and logs to .gitignore

## Testing
- `pytest` *(fails: httpx missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a602ddc960832fa15f3d41c2236466