### PR TITLE
Use auth tokens in user and book tests

### DIFF
--- a/backend/tests/test_books.py
+++ b/backend/tests/test_books.py
@@ -1,22 +1,28 @@
 
 def test_create_and_read_book(client):
-    user_resp = client.post("/users/", json={"email": "b@example.com", "password": "secret"})
-    user_id = user_resp.json()["id"]
+    client.post(
+        "/users/register", json={"email": "b@example.com", "password": "secret"}
+    )
+    login_resp = client.post(
+        "/users/login", json={"email": "b@example.com", "password": "secret"}
+    )
+    token = login_resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
 
-    response = client.post("/books/", json={"title": "Book", "owner_id": user_id})
+    response = client.post("/books/", json={"title": "Book"}, headers=headers)
     assert response.status_code == 200
     data = response.json()
     assert data["title"] == "Book"
-    assert data["owner_id"] == user_id
+    assert data["owner_id"] == 1
     book_id = data["id"]
 
-    get_resp = client.get(f"/books/{book_id}")
+    get_resp = client.get(f"/books/{book_id}", headers=headers)
     assert get_resp.status_code == 200
     fetched = get_resp.json()
     assert fetched["title"] == "Book"
-    assert fetched["owner_id"] == user_id
+    assert fetched["owner_id"] == 1
 
-    list_resp = client.get("/books/")
+    list_resp = client.get("/books/", headers=headers)
     assert list_resp.status_code == 200
     books = list_resp.json()
     assert any(b["id"] == book_id for b in books)


### PR DESCRIPTION
## Summary
- Adjust user tests to register and log in, asserting token-based responses
- Update book tests to authenticate via login token and rely on automatic ownership

## Testing
- `PYTHONPATH=. pytest -q` *(fails: pydantic.errors.PydanticImportError: `BaseSettings` has been moved to the `pydantic-settings` package)*

------
https://chatgpt.com/codex/tasks/task_e_68a612389b70832f9027b9fbecb174da