### PR TITLE
Use settings-based JWT configuration

### DIFF
--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -9,9 +9,8 @@ from sqlmodel import Session
 
 from .db import get_session
 from .models import User
+from .config import settings
 
-SECRET_KEY = "secret-key"
-ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -27,7 +26,7 @@ def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -
     to_encode = data.copy()
     expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
     to_encode.update({"exp": expire})
-    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return jwt.encode(to_encode, settings.jwt_secret, algorithm=settings.jwt_algorithm)
 
 def get_current_user(
     token: str = Depends(oauth2_scheme),
@@ -39,7 +38,7 @@ def get_current_user(
         headers={"WWW-Authenticate": "Bearer"},
     )
     try:
-        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        payload = jwt.decode(token, settings.jwt_secret, algorithms=[settings.jwt_algorithm])
         user_id: Optional[str] = payload.get("sub")
         if user_id is None:
             raise credentials_exception


### PR DESCRIPTION
## Summary
- Replace hard-coded JWT secret and algorithm with configuration values from `settings`
- Update token creation and validation to use `settings.jwt_secret` and `settings.jwt_algorithm`

## Testing
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError / PydanticImportError)*
- `pip install 'pydantic<2'` *(fails: Could not find a matching distribution due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68a6188810ac832fa16d7bfacf3ce182