### PR TITLE
Implement EPUB parser and Cinematic Markup converter

### DIFF
--- a/backend/app/services/converter.py
+++ b/backend/app/services/converter.py
@@ -1,18 +1,42 @@
-"""Conversion logic for generating Cinematic Markup from parsed content.
+"""Conversion logic for generating Cinematic Markup from parsed content."""
 
-This module contains placeholder functions representing the core
-transformation pipeline.
-"""
+from __future__ import annotations
+
+from typing import Dict, List
 
 
-def generate_cinematic_markup(parsed_book: dict) -> dict:
+def generate_cinematic_markup(parsed_book: Dict[str, object]) -> Dict[str, object]:
     """Convert parsed book data into Cinematic Markup JSON structure.
+
+    The transformation implemented here is intentionally simple: each paragraph
+    from the parsed book becomes an entry in the ``content`` list with the
+    ``paragraph`` type and an empty ``effects`` list. This provides a predictable
+    structure for clients while leaving room for future enhancement logic.
 
     Args:
         parsed_book: Output from the parser containing structured book data.
 
     Returns:
-        A dictionary following the Cinematic Markup schema.
+        A dictionary following the Cinematic Markup schema as outlined in the
+        project ``README``.
     """
-    # TODO: Implement conversion logic
-    return {}
+
+    chapters_markup: List[Dict[str, object]] = []
+
+    for chapter in parsed_book.get("chapters", []):
+        content: List[Dict[str, object]] = []
+        for paragraph in chapter.get("paragraphs", []):
+            content.append({"type": "paragraph", "text": paragraph, "effects": []})
+
+        chapters_markup.append(
+            {
+                "chapterTitle": chapter.get("title"),
+                "content": content,
+            }
+        )
+
+    return {
+        "bookTitle": parsed_book.get("title"),
+        "theme": parsed_book.get("theme", "default"),
+        "chapters": chapters_markup,
+    }

--- a/backend/app/services/parser.py
+++ b/backend/app/services/parser.py
@@ -1,17 +1,67 @@
-"""Utilities for parsing EPUB files into structured content.
+"""Utilities for parsing EPUB files into structured content."""
 
-Currently a placeholder for future implementation.
-"""
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+import zipfile
+from pathlib import Path
+from typing import Dict, List
 
 
-def parse_epub(epub_file_path: str) -> dict:
-    """Parse an EPUB file and return a structured representation.
+def _get_rootfile_path(zf: zipfile.ZipFile) -> str:
+    container = ET.fromstring(zf.read("META-INF/container.xml"))
+    ns = {"c": "urn:oasis:names:tc:opendocument:xmlns:container"}
+    rootfile = container.find("c:rootfiles/c:rootfile", ns)
+    return rootfile.attrib["full-path"]
 
-    Args:
-        epub_file_path: Path to the EPUB file.
 
-    Returns:
-        A dictionary representing the book's structure.
-    """
-    # TODO: Implement EPUB parsing logic
-    return {}
+def _parse_content_opf(content: bytes) -> Dict[str, object]:
+    ns = {
+        "opf": "http://www.idpf.org/2007/opf",
+        "dc": "http://purl.org/dc/elements/1.1/",
+    }
+    root = ET.fromstring(content)
+    title_elem = root.find("opf:metadata/dc:title", ns)
+    title = title_elem.text if title_elem is not None else ""
+
+    manifest = {
+        item.attrib["id"]: item.attrib["href"]
+        for item in root.find("opf:manifest", ns)
+    }
+    spine_ids = [i.attrib["idref"] for i in root.find("opf:spine", ns)]
+    return {"title": title, "manifest": manifest, "spine": spine_ids}
+
+
+def _parse_chapter(html: bytes) -> Dict[str, object]:
+    ns = {"x": "http://www.w3.org/1999/xhtml"}
+    root = ET.fromstring(html)
+
+    title_elem = None
+    for tag in ["h1", "h2", "h3"]:
+        title_elem = root.find(f".//x:{tag}", ns)
+        if title_elem is not None:
+            break
+    title = title_elem.text if title_elem is not None else ""
+
+    paragraphs = [p.text or "" for p in root.findall(".//x:p", ns)]
+    return {"title": title, "paragraphs": paragraphs}
+
+
+def parse_epub(epub_file_path: str) -> Dict[str, object]:
+    """Parse an EPUB file and return a structured representation."""
+
+    with zipfile.ZipFile(epub_file_path, "r") as zf:
+        rootfile_path = _get_rootfile_path(zf)
+        content_info = _parse_content_opf(zf.read(rootfile_path))
+
+        base_path = Path(rootfile_path).parent
+        chapters: List[Dict[str, object]] = []
+        for idref in content_info["spine"]:
+            href = content_info["manifest"].get(idref)
+            if not href:
+                continue
+            chapter_path = str(base_path / href)
+            chapter_html = zf.read(chapter_path)
+            chapters.append(_parse_chapter(chapter_html))
+
+    return {"title": content_info["title"], "chapters": chapters}

--- a/backend/tests/test_parser_converter.py
+++ b/backend/tests/test_parser_converter.py
@@ -1,0 +1,77 @@
+import zipfile
+
+from backend.app.services.converter import generate_cinematic_markup
+from backend.app.services.parser import parse_epub
+
+
+def _create_sample_epub(tmp_path):
+    """Create a simple EPUB book for testing and return its path."""
+
+    epub_path = tmp_path / "sample.epub"
+    with zipfile.ZipFile(epub_path, "w") as zf:
+        # Required mimetype file must be stored without compression
+        zf.writestr("mimetype", "application/epub+zip", compress_type=zipfile.ZIP_STORED)
+
+        container_xml = (
+            "<?xml version='1.0' encoding='utf-8'?>\n"
+            "<container version='1.0' xmlns='urn:oasis:names:tc:opendocument:xmlns:container'>"
+            "<rootfiles><rootfile full-path='OEBPS/content.opf' "
+            "media-type='application/oebps-package+xml'/></rootfiles></container>"
+        )
+        zf.writestr("META-INF/container.xml", container_xml)
+
+        content_opf = (
+            "<?xml version='1.0' encoding='utf-8'?>\n"
+            "<package xmlns='http://www.idpf.org/2007/opf' version='3.0'>"
+            "<metadata xmlns:dc='http://purl.org/dc/elements/1.1/'>"
+            "<dc:title>Sample Book</dc:title></metadata>"
+            "<manifest><item id='ch1' href='ch1.xhtml' media-type='application/xhtml+xml'/></manifest>"
+            "<spine><itemref idref='ch1'/></spine></package>"
+        )
+        zf.writestr("OEBPS/content.opf", content_opf)
+
+        chapter_html = (
+            "<html xmlns='http://www.w3.org/1999/xhtml'><head><title>Chapter 1</title></head>"
+            "<body><h1>Chapter 1</h1><p>Hello world.</p><p>Second paragraph.</p></body></html>"
+        )
+        zf.writestr("OEBPS/ch1.xhtml", chapter_html)
+
+    return epub_path
+
+
+def test_parse_epub(tmp_path):
+    epub_path = _create_sample_epub(tmp_path)
+    parsed = parse_epub(str(epub_path))
+
+    assert parsed["title"] == "Sample Book"
+    assert len(parsed["chapters"]) == 1
+    chapter = parsed["chapters"][0]
+    assert chapter["title"] == "Chapter 1"
+    assert chapter["paragraphs"] == ["Hello world.", "Second paragraph."]
+
+
+def test_generate_cinematic_markup():
+    parsed_book = {
+        "title": "Sample Book",
+        "chapters": [
+            {
+                "title": "Chapter 1",
+                "paragraphs": ["Hello world.", "Second paragraph."],
+            }
+        ],
+    }
+
+    markup = generate_cinematic_markup(parsed_book)
+
+    assert markup["bookTitle"] == "Sample Book"
+    assert markup["theme"] == "default"
+    assert len(markup["chapters"]) == 1
+    chapter_markup = markup["chapters"][0]
+    assert chapter_markup["chapterTitle"] == "Chapter 1"
+    assert chapter_markup["content"][0] == {
+        "type": "paragraph",
+        "text": "Hello world.",
+        "effects": [],
+    }
+    assert chapter_markup["content"][1]["text"] == "Second paragraph."
+


### PR DESCRIPTION
## Summary
- parse EPUB archives using standard library modules to extract chapter titles and text
- convert parsed data into basic Cinematic Markup structure
- add unit tests covering parsing and markup generation

## Testing
- `PYTHONPATH=. pytest backend/tests/test_parser_converter.py` *(fails: pydantic.errors.PydanticImportError)*
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a61bde0474832fa684f975c6c02bfb