### PR TITLE
Add book upload endpoint with markup persistence

### DIFF
--- a/backend/app/models/book.py
+++ b/backend/app/models/book.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from typing import Optional
 
+from sqlalchemy import Column, JSON
 from sqlmodel import Field, Relationship, SQLModel
 
 
@@ -11,5 +12,6 @@ class Book(SQLModel, table=True):
     title: str
     author: Optional[str] = None
     owner_id: Optional[int] = Field(default=None, foreign_key="user.id")
+    markup: Optional[dict] = Field(default=None, sa_column=Column(JSON))
 
     owner: Optional["User"] = Relationship(back_populates="books")

--- a/backend/tests/test_books.py
+++ b/backend/tests/test_books.py
@@ -1,4 +1,7 @@
 
+import zipfile
+
+
 def test_create_and_read_book(client):
     client.post(
         "/users/register", json={"email": "b@example.com", "password": "secret"}
@@ -26,3 +29,73 @@ def test_create_and_read_book(client):
     assert list_resp.status_code == 200
     books = list_resp.json()
     assert any(b["id"] == book_id for b in books)
+
+
+def _create_sample_epub(tmp_path):
+    epub_path = tmp_path / "sample.epub"
+    with zipfile.ZipFile(epub_path, "w") as zf:
+        zf.writestr("mimetype", "application/epub+zip", compress_type=zipfile.ZIP_STORED)
+        container_xml = (
+            "<?xml version='1.0' encoding='utf-8'?>\n"
+            "<container version='1.0' xmlns='urn:oasis:names:tc:opendocument:xmlns:container'>"
+            "<rootfiles><rootfile full-path='OEBPS/content.opf' media-type='application/oebps-package+xml'/></rootfiles></container>"
+        )
+        zf.writestr("META-INF/container.xml", container_xml)
+        content_opf = (
+            "<?xml version='1.0' encoding='utf-8'?>\n"
+            "<package xmlns='http://www.idpf.org/2007/opf' version='3.0'>"
+            "<metadata xmlns:dc='http://purl.org/dc/elements/1.1/'><dc:title>Sample Book</dc:title></metadata>"
+            "<manifest><item id='ch1' href='ch1.xhtml' media-type='application/xhtml+xml'/></manifest>"
+            "<spine><itemref idref='ch1'/></spine></package>"
+        )
+        zf.writestr("OEBPS/content.opf", content_opf)
+        chapter_html = (
+            "<html xmlns='http://www.w3.org/1999/xhtml'><head><title>Chapter 1</title></head>"
+            "<body><h1>Chapter 1</h1><p>Hello world.</p><p>Second paragraph.</p></body></html>"
+        )
+        zf.writestr("OEBPS/ch1.xhtml", chapter_html)
+    return epub_path
+
+
+def test_upload_book_success(client, tmp_path):
+    client.post("/users/register", json={"email": "c@example.com", "password": "secret"})
+    login_resp = client.post(
+        "/users/login", json={"email": "c@example.com", "password": "secret"}
+    )
+    token = login_resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    epub_path = _create_sample_epub(tmp_path)
+    with open(epub_path, "rb") as f:
+        resp = client.post(
+            "/books/upload",
+            files={"file": ("sample.epub", f, "application/epub+zip")},
+            headers=headers,
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["bookTitle"] == "Sample Book"
+
+    list_resp = client.get("/books/", headers=headers)
+    assert list_resp.status_code == 200
+    books = list_resp.json()
+    assert books[0]["markup"]["bookTitle"] == "Sample Book"
+
+
+def test_upload_book_invalid_file(client, tmp_path):
+    client.post("/users/register", json={"email": "d@example.com", "password": "secret"})
+    login_resp = client.post(
+        "/users/login", json={"email": "d@example.com", "password": "secret"}
+    )
+    token = login_resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    bad_path = tmp_path / "bad.epub"
+    bad_path.write_bytes(b"not an epub")
+    with open(bad_path, "rb") as f:
+        resp = client.post(
+            "/books/upload",
+            files={"file": ("bad.epub", f, "application/epub+zip")},
+            headers=headers,
+        )
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- support uploading EPUBs and generating cinematic markup
- store generated markup on Book records
- test book upload success and failure cases

## Testing
- `pip install 'pydantic<2'` *(fails: Could not find a version that satisfies the requirement pydantic<2)*
- `PYTHONPATH=. pytest -q` *(fails: `BaseSettings` has been moved to the `pydantic-settings` package)*

------
https://chatgpt.com/codex/tasks/task_e_68a6201e63f0832f83b4c6966a585ef1