### PR TITLE
Add per-effect user preferences and settings UI

### DIFF
--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -5,11 +5,27 @@ from sqlalchemy import Column, JSON
 from sqlmodel import Field, SQLModel
 
 
+def default_preferences() -> dict:
+    """Default nested preferences for a new user."""
+    return {
+        "effectsEnabled": True,
+        "fontSize": 16,
+        "brightness": 1.0,
+        "adaptiveBrightness": False,
+        "effects": {
+            "motion": {"enabled": True, "intensity": 1.0},
+            "color": {"enabled": True, "intensity": 1.0},
+        },
+    }
+
+
 class User(SQLModel, table=True):
     """Database model for application users."""
 
     id: Optional[int] = Field(default=None, primary_key=True)
     email: str = Field(index=True)
     hashed_password: str = Field(..., min_length=1)
-    preferences: dict = Field(default_factory=dict, sa_column=Column(JSON))
+    preferences: dict = Field(
+        default_factory=default_preferences, sa_column=Column(JSON)
+    )
 

--- a/backend/tests/test_preferences.py
+++ b/backend/tests/test_preferences.py
@@ -18,14 +18,22 @@ def test_user_preferences_roundtrip(client):
         "effectsEnabled": True,
         "fontSize": 16,
         "brightness": 1.0,
-        "effectIntensity": 1.0,
+        "adaptiveBrightness": False,
+        "effects": {
+            "motion": {"enabled": True, "intensity": 1.0},
+            "color": {"enabled": True, "intensity": 1.0},
+        },
     }
 
     prefs = {
         "effectsEnabled": False,
         "fontSize": 20,
         "brightness": 0.8,
-        "effectIntensity": 0.7,
+        "adaptiveBrightness": True,
+        "effects": {
+            "motion": {"enabled": False, "intensity": 0.4},
+            "color": {"enabled": True, "intensity": 0.9},
+        },
     }
     put_resp = client.put("/users/me/preferences", headers=headers, json=prefs)
     assert put_resp.status_code == 200

--- a/client/__tests__/settingsScreen.test.js
+++ b/client/__tests__/settingsScreen.test.js
@@ -1,0 +1,11 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const file = path.join(__dirname, '..', 'components', 'SettingsScreen.js');
+const content = fs.readFileSync(file, 'utf8');
+
+assert.ok(content.includes('Adaptive Brightness'), 'missing adaptive brightness toggle');
+assert.ok(content.includes('effectsConfig'), 'missing per-effect configuration');
+assert.ok(content.includes('intensity'), 'missing effect intensity slider');
+console.log('settings screen ui passed');

--- a/client/components/SettingsScreen.js
+++ b/client/components/SettingsScreen.js
@@ -15,12 +15,14 @@ export default function SettingsScreen({
   onSave,
   effectsEnabled,
   setEffectsEnabled,
+  effectsConfig,
+  setEffectsConfig,
   fontSize,
   setFontSize,
   brightness,
   setBrightness,
-  effectIntensity,
-  setEffectIntensity
+  adaptiveBrightness,
+  setAdaptiveBrightness,
 }) {
   const handleBack = () => {
     if (onSave) {
@@ -74,6 +76,18 @@ export default function SettingsScreen({
               minimumTrackTintColor="#3498db"
               maximumTrackTintColor="#bdc3c7"
               thumbStyle={styles.sliderThumb}
+              disabled={adaptiveBrightness}
+            />
+          </View>
+
+          {/* Adaptive Brightness */}
+          <View style={styles.settingItem}>
+            <Text style={styles.settingLabel}>Adaptive Brightness</Text>
+            <Switch
+              value={adaptiveBrightness}
+              onValueChange={setAdaptiveBrightness}
+              trackColor={{ false: '#bdc3c7', true: '#3498db' }}
+              thumbColor={adaptiveBrightness ? '#ffffff' : '#f4f3f4'}
             />
           </View>
         </View>
@@ -93,22 +107,48 @@ export default function SettingsScreen({
             />
           </View>
 
-          {/* Effect Intensity */}
-          {effectsEnabled && (
-            <View style={styles.settingItem}>
-              <Text style={styles.settingLabel}>Effect Intensity: {Math.round(effectIntensity * 100)}%</Text>
-              <Slider
-                style={styles.slider}
-                minimumValue={0.1}
-                maximumValue={1.0}
-                value={effectIntensity}
-                onValueChange={setEffectIntensity}
-                minimumTrackTintColor="#3498db"
-                maximumTrackTintColor="#bdc3c7"
-                thumbStyle={styles.sliderThumb}
-              />
-            </View>
-          )}
+          {/* Per-effect Configuration */}
+          {effectsEnabled &&
+            Object.entries(effectsConfig).map(([name, config]) => (
+              <View key={name}>
+                <View style={styles.settingItem}>
+                  <Text style={styles.settingLabel}>{name} Enabled</Text>
+                  <Switch
+                    value={config.enabled}
+                    onValueChange={(value) =>
+                      setEffectsConfig({
+                        ...effectsConfig,
+                        [name]: { ...config, enabled: value },
+                      })
+                    }
+                    trackColor={{ false: '#bdc3c7', true: '#3498db' }}
+                    thumbColor={config.enabled ? '#ffffff' : '#f4f3f4'}
+                  />
+                </View>
+                {config.enabled && (
+                  <View style={styles.settingItem}>
+                    <Text style={styles.settingLabel}>
+                      {name} Intensity: {Math.round(config.intensity * 100)}%
+                    </Text>
+                    <Slider
+                      style={styles.slider}
+                      minimumValue={0.1}
+                      maximumValue={1.0}
+                      value={config.intensity}
+                      onValueChange={(value) =>
+                        setEffectsConfig({
+                          ...effectsConfig,
+                          [name]: { ...config, intensity: value },
+                        })
+                      }
+                      minimumTrackTintColor="#3498db"
+                      maximumTrackTintColor="#bdc3c7"
+                      thumbStyle={styles.sliderThumb}
+                    />
+                  </View>
+                )}
+              </View>
+            ))}
         </View>
 
         {/* About */}


### PR DESCRIPTION
## Summary
- allow nested per-effect user preference storage with defaults
- expand user preferences API validation and persistence
- render per-effect controls and adaptive brightness in settings screen
- add backend and client tests for preference round-trip and UI checks

## Testing
- `JWT_SECRET=secret DATABASE_URL=sqlite:// PYTHONPATH=. pytest backend/tests`
- `node client/__tests__/offlineSync.test.js`
- `node client/__tests__/settingsScreen.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a66ab85480832fa5f6ee020b38d08c