### PR TITLE
Integrate transformer sentiment analysis into emotional scorer

### DIFF
--- a/backend/tests/test_intelligent_analysis.py
+++ b/backend/tests/test_intelligent_analysis.py
@@ -195,6 +195,28 @@ def create_sample_books():
     return sample_books
 
 
+def test_emotion_scorer_model_integration():
+    """Ensure model sentiment is incorporated into emotional weighting."""
+    scorer = EmotionalIntensityScorer()
+
+    # Stub out heuristics to isolate model contribution
+    scorer._analyze_dialogue_emotion = lambda text: 0.0
+    scorer._measure_action_pacing = lambda text: 0.0
+    scorer._assess_sensory_language = lambda text: 0.0
+    scorer._evaluate_conflict_intensity = lambda text: 0.0
+    scorer._assess_character_openness = lambda text, profiles: 0.0
+    scorer._calculate_narrative_context_weight = lambda item, structure: 1.0
+
+    # Provide a deterministic sentiment analyzer
+    scorer.sentiment_analyzer = lambda t: [{"label": "POSITIVE", "score": 0.75}]
+
+    content_item = {"text": "A short sentence."}
+    score = scorer.calculate_emotional_weight(content_item, {}, {})
+
+    expected = scorer.emotion_weights["model_sentiment"] * 0.75
+    assert abs(score - expected) < 1e-6
+
+
 def test_theme_specific_effect_application():
     """Verify that effects are filtered by theme before evaluation."""
     selector = IntelligentEffectSelector()


### PR DESCRIPTION
## Summary
- Incorporate Hugging Face transformer pipeline for sentiment analysis in `EmotionalIntensityScorer`
- Blend classifier output with existing heuristics and confidence-weighted scoring
- Add test ensuring model-based sentiment path is correctly included

## Testing
- `DATABASE_URL=sqlite:// JWT_SECRET=test JWT_ALGORITHM=HS256 PYTHONPATH=.. pytest tests/test_intelligent_analysis.py::test_emotion_scorer_model_integration -q`
- `DATABASE_URL=sqlite:// JWT_SECRET=test JWT_ALGORITHM=HS256 PYTHONPATH=.. pytest tests/test_intelligent_analysis.py -q`
- `JWT_SECRET=test JWT_ALGORITHM=HS256 DATABASE_URL=sqlite:// PYTHONPATH=.. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6799cda68832fbb97f0d8126c68f5