### PR TITLE
Unify chapter content structure in parser and services

### DIFF
--- a/backend/app/services/converter.py
+++ b/backend/app/services/converter.py
@@ -8,8 +8,8 @@ from typing import Dict, List
 def generate_cinematic_markup(parsed_book: Dict[str, object]) -> Dict[str, object]:
     """Convert parsed book data into Cinematic Markup JSON structure.
 
-    The transformation implemented here is intentionally simple: each paragraph
-    from the parsed book becomes an entry in the ``content`` list with the
+    The transformation implemented here is intentionally simple: each content
+    item from the parsed book becomes an entry in the ``content`` list with the
     ``paragraph`` type and an empty ``effects`` list. This provides a predictable
     structure for clients while leaving room for future enhancement logic.
 
@@ -25,8 +25,9 @@ def generate_cinematic_markup(parsed_book: Dict[str, object]) -> Dict[str, objec
 
     for chapter in parsed_book.get("chapters", []):
         content: List[Dict[str, object]] = []
-        for paragraph in chapter.get("paragraphs", []):
-            content.append({"type": "paragraph", "text": paragraph, "effects": []})
+        for item in chapter.get("content", []):
+            text = item.get("text", "")
+            content.append({"type": "paragraph", "text": text, "effects": []})
 
         chapters_markup.append(
             {

--- a/backend/app/services/parser.py
+++ b/backend/app/services/parser.py
@@ -43,8 +43,8 @@ def _parse_chapter(html: bytes) -> Dict[str, object]:
             break
     title = title_elem.text if title_elem is not None else ""
 
-    paragraphs = [p.text or "" for p in root.findall(".//x:p", ns)]
-    return {"title": title, "paragraphs": paragraphs}
+    content = [{"text": p.text or ""} for p in root.findall(".//x:p", ns)]
+    return {"title": title, "content": content}
 
 
 def parse_epub(epub_file_path: str) -> Dict[str, object]:


### PR DESCRIPTION
## Summary
- Parse EPUB chapters into `content` lists of text objects
- Update converter and analysis pipeline tests for new structure
- Add regression test ensuring analyzed chapters retain content

## Testing
- `PYTHONPATH=. DATABASE_URL=sqlite:// JWT_SECRET=secret pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6a3de15f0832f8840a3aaf5917628