### PR TITLE
Add dialogue detection helper and tests

### DIFF
--- a/backend/app/services/emotion_scorer.py
+++ b/backend/app/services/emotion_scorer.py
@@ -8,6 +8,7 @@ when and how effects should be applied while maintaining the "book is the star" 
 from __future__ import annotations
 from typing import Dict, List, Any, Optional
 import logging
+from .utils import contains_dialogue
 
 try:  # Optional dependency for model-based sentiment analysis
     from transformers import pipeline  # type: ignore
@@ -168,9 +169,7 @@ class EmotionalIntensityScorer:
         text_lower = text.lower()
         
         # Check for dialogue markers
-        has_dialogue = '"' in text or '"' in text or '"' in text
-        
-        if not has_dialogue:
+        if not contains_dialogue(text):
             return 0.1  # Low emotion for non-dialogue
         
         # Analyze dialogue emotion

--- a/backend/app/services/structural_analyzer.py
+++ b/backend/app/services/structural_analyzer.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Dict, List, Any, Optional
 import re
 import logging
+from .utils import contains_dialogue
 
 logger = logging.getLogger(__name__)
 
@@ -263,7 +264,7 @@ class StoryStructureAnalyzer:
         
         for item in content:
             text = item.get('text', '')
-            if self._contains_dialogue(text):
+            if contains_dialogue(text):
                 dialogue_count += 1
         
         return dialogue_count / total_segments
@@ -393,7 +394,7 @@ class StoryStructureAnalyzer:
         for item in content:
             text = item.get('text', '')
             # Simple character detection (would be enhanced)
-            if '"' in text:  # Dialogue
+            if contains_dialogue(text):  # Dialogue
                 emotion_score = self._calculate_dialogue_emotion(text)
                 character_emotions['speaker'] = emotion_score
         
@@ -406,10 +407,6 @@ class StoryStructureAnalyzer:
         
         word_count = len(text.split())
         return emotion_count / word_count if word_count > 0 else 0.0
-    
-    def _contains_dialogue(self, text: str) -> bool:
-        """Check if text contains dialogue."""
-        return '"' in text or '"' in text or '"' in text
     
     def _is_scene_transition(self, text: str) -> bool:
         """Check if text represents a scene transition."""

--- a/backend/app/services/utils.py
+++ b/backend/app/services/utils.py
@@ -1,0 +1,7 @@
+import re
+
+_DIALOGUE_RE = re.compile(r"['\"]")
+
+def contains_dialogue(text: str) -> bool:
+    """Return True if text contains dialogue indicated by single or double quotes."""
+    return bool(_DIALOGUE_RE.search(text))

--- a/backend/tests/test_dialogue_detection.py
+++ b/backend/tests/test_dialogue_detection.py
@@ -1,0 +1,35 @@
+import pytest
+
+from backend.app.services.utils import contains_dialogue
+from backend.app.services.structural_analyzer import StoryStructureAnalyzer
+from backend.app.services.emotion_scorer import EmotionalIntensityScorer
+
+
+def test_contains_dialogue_detects_double_quotes():
+    assert contains_dialogue('He said, "Hello."')
+
+
+def test_contains_dialogue_detects_single_quotes():
+    assert contains_dialogue("He said, 'Hello.'")
+
+
+def test_contains_dialogue_false_when_no_quotes():
+    assert not contains_dialogue('No dialogue here')
+
+
+def test_structural_analyzer_dialogue_density_with_both_quote_styles():
+    analyzer = StoryStructureAnalyzer()
+    content = [
+        {'text': 'He said, "Hello."'},
+        {"text": "She replied, 'Hi.'"},
+        {'text': 'No dialogue.'},
+    ]
+    assert analyzer._calculate_dialogue_density(content) == pytest.approx(2 / 3)
+
+
+def test_emotion_scorer_detects_dialogue_with_quote_styles():
+    scorer = EmotionalIntensityScorer()
+    assert scorer._analyze_dialogue_emotion('He shouted, "I am angry!"') > 0.0
+    assert scorer._analyze_dialogue_emotion("She whispered, 'I am sad.'") > 0.0
+    assert scorer._analyze_dialogue_emotion('No dialogue here.') == 0.1
+


### PR DESCRIPTION
## Summary
- add `contains_dialogue` helper to detect single and double quoted dialogue
- use helper in structural analyzer and emotion scorer
- cover dialogue detection with new unit tests

## Testing
- `PYTHONPATH=. DATABASE_URL=sqlite:// JWT_SECRET=secret pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a6a602c82c832f90a19bf3923112c9