### PR TITLE
Fix effect distribution average calculation and add test

### DIFF
--- a/backend/app/services/story_analyzer.py
+++ b/backend/app/services/story_analyzer.py
@@ -230,11 +230,11 @@ class StoryAnalyzer:
         for effect in effect_history:
             chapter = effect['chapter']
             chapter_distribution[chapter] = chapter_distribution.get(chapter, 0) + 1
-        
+
         return {
             'total_effects': len(effect_history),
             'distribution': chapter_distribution,
-            'average_effects_per_chapter': len(effect_history) / max(chapter_distribution.keys()) if chapter_distribution else 0
+            'average_effects_per_chapter': len(effect_history) / len(chapter_distribution)
         }
     
     def _analyze_character_effect_usage(self, effect_history: List[Dict], character_profiles: Dict) -> Dict[str, int]:

--- a/backend/tests/test_story_analyzer.py
+++ b/backend/tests/test_story_analyzer.py
@@ -1,0 +1,16 @@
+import pytest
+
+from backend.app.services.story_analyzer import StoryAnalyzer
+
+
+def test_effect_distribution_average_multiple_chapters():
+    analyzer = StoryAnalyzer()
+    effect_history = [
+        {"chapter": 0, "position": 0, "effects": ["rain"]},
+        {"chapter": 1, "position": 1, "effects": ["wind"]},
+        {"chapter": 1, "position": 2, "effects": ["light"]},
+    ]
+
+    stats = analyzer._analyze_effect_distribution(effect_history)
+    assert stats["distribution"] == {0: 1, 1: 2}
+    assert stats["average_effects_per_chapter"] == pytest.approx(1.5)


### PR DESCRIPTION
## Summary
- correct average effects per chapter by dividing by number of chapters with effects
- add test ensuring average computation across multiple chapters

## Testing
- `PYTHONPATH=. pytest -q` *(fails: test_registration_login_and_protected_routes, test_create_and_read_book, test_parse_epub, test_story_analyzer_processes_chapters, test_user_preferences_roundtrip)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a771e95c832fbcc0bbc4ea87354a