### PR TITLE
Use plain dict for preferences update

### DIFF
--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -29,6 +29,9 @@ class User(SQLModel, table=True):
     is_active: bool = Field(default=True)
     created_at: datetime = Field(default_factory=datetime.utcnow, sa_column=Column(DateTime))
     updated_at: datetime = Field(default_factory=datetime.utcnow, sa_column=Column(DateTime))
+    preferences: Dict[str, Any] = Field(
+        default_factory=default_preferences, sa_column=Column(JSON)
+    )
 
 
 class UserPreferences(SQLModel, table=True):

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -94,7 +94,7 @@ def update_preferences(
     session: Session = Depends(get_session),
     current_user: User = Depends(get_current_user),
 ):
-    current_user.preferences = prefs.model_dump()
+    current_user.preferences = prefs.dict()
     session.add(current_user)
     session.commit()
     session.refresh(current_user)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,7 +16,7 @@ python-jose[cryptography]>=3.3.0
 httpx>=0.25.0
 
 # Data Validation
-pydantic>=2.5.0
+pydantic>=1.10,<3
 
 # Environment & Configuration
 python-dotenv>=1.0.0

--- a/backend/tests/test_preferences.py
+++ b/backend/tests/test_preferences.py
@@ -43,3 +43,25 @@ def test_user_preferences_roundtrip(client):
     assert get_resp.status_code == 200
     assert get_resp.json() == prefs
 
+
+def test_partial_preference_update(client):
+    register_resp = client.post(
+        "/users/register", json={"email": "partial@example.com", "password": "secret"}
+    )
+    assert register_resp.status_code == 200
+
+    login_resp = client.post(
+        "/users/login", json={"email": "partial@example.com", "password": "secret"}
+    )
+    assert login_resp.status_code == 200
+    token = login_resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    update = {"fontSize": 24}
+    put_resp = client.put("/users/me/preferences", headers=headers, json=update)
+    assert put_resp.status_code == 200
+    assert put_resp.json()["fontSize"] == 24
+
+    get_resp = client.get("/users/me/preferences", headers=headers)
+    assert get_resp.status_code == 200
+    assert get_resp.json()["fontSize"] == 24


### PR DESCRIPTION
## Summary
- store user preferences directly as JSON field
- replace `model_dump()` with `dict()` for wider Pydantic compatibility
- relax Pydantic requirement to `>=1.10,<3`
- add test covering partial preference update

## Testing
- ⚠️ `PYTHONPATH=/workspace/Storyboard pytest -q` (fails: books routes & parser tests)
- ✅ `PYTHONPATH=/workspace/Storyboard pytest backend/tests/test_preferences.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6aa676d28832f86d4ca0be35dad14