### PR TITLE
chore: remove unused Optional import from config

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,6 +1,5 @@
 from pydantic import BaseModel
 import os
-from typing import Optional
 
 # Load environment variables from .env file
 try:


### PR DESCRIPTION
## Summary
- drop unused Optional import in `backend/app/config.py`

## Testing
- `ruff check backend/app/config.py`
- `PYTHONPATH=. pytest -q` *(fails: test_registration_login_and_protected_routes, test_create_and_read_book, test_parse_epub, test_story_analyzer_processes_chapters)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b2c14f6c832f822b35f93a16faeb