### PR TITLE
chore: remove unused SQLAlchemy imports

### DIFF
--- a/backend/app/models/book.py
+++ b/backend/app/models/book.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import Optional, Dict, Any
 from datetime import datetime
 
-from sqlalchemy import Column, JSON, DateTime, String, Integer, Text
+from sqlalchemy import Column, JSON, DateTime
 from sqlmodel import Field, SQLModel
 
 


### PR DESCRIPTION
## Summary
- remove unused SQLAlchemy imports from Book model

## Testing
- `ruff check backend/app/models/book.py`
- `PYTHONPATH=. pytest -q` *(fails: assert 405 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b47ca058832f91b581cd9bba5b3d