### PR TITLE
chore: clean up unused SQLAlchemy imports in user model

### DIFF
--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import Optional, Dict, Any
 from datetime import datetime
 
-from sqlalchemy import Column, JSON, DateTime, String, Boolean, Float, Integer
+from sqlalchemy import Column, JSON, DateTime
 from sqlmodel import Field, SQLModel
 
 


### PR DESCRIPTION
## Summary
- remove unused `String`, `Boolean`, `Float`, and `Integer` imports from `backend/app/models/user.py`

## Testing
- `ruff check backend/app/models/user.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*
- `PYTHONPATH=. pytest -q` *(fails: 4 failed, 19 passed, 1 skipped)*


------
https://chatgpt.com/codex/tasks/task_e_68a6b680d2c0832fb618b6575c2e937c