### PR TITLE
chore: remove unused typing imports

### DIFF
--- a/backend/app/services/parser.py
+++ b/backend/app/services/parser.py
@@ -6,7 +6,7 @@ import xml.etree.ElementTree as ET
 import zipfile
 import re
 from pathlib import Path
-from typing import Dict, List, Optional, Any
+from typing import Any, Dict
 import logging
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- remove unused typing imports from parser service

## Testing
- `ruff check backend/app/services/parser.py`
- `PYTHONPATH=. pytest -q` *(fails: assert 405 == 200, assert 0 == 1, AssertionError: No chapters returned)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b7c75e40832f83552429397cfde7