### PR TITLE
chore: remove unused imports in sparsity controller

### DIFF
--- a/backend/app/services/sparsity_controller.py
+++ b/backend/app/services/sparsity_controller.py
@@ -6,9 +6,9 @@ and meaningfully. Prevents overuse and maintains the "book is the star" principl
 """
 
 from __future__ import annotations
-from typing import Dict, List, Any, Optional
+
 import logging
-import random
+from typing import Any, Dict, List
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- clean up unused Optional and random imports in sparsity controller

## Testing
- `ruff check backend/app/services/sparsity_controller.py`
- `PYTHONPATH=$PWD pytest -q` *(fails: assert 405 == 200, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b7cd0f8c832fbf4f07ce5131ea76