### PR TITLE
chore: remove unused shutil import

### DIFF
--- a/backend/app/routers/books.py
+++ b/backend/app/routers/books.py
@@ -3,7 +3,6 @@ from sqlmodel import Session, select
 from typing import List
 import os
 import tempfile
-import shutil
 from datetime import datetime
 
 from ..db import get_session


### PR DESCRIPTION
## Summary
- remove unused `shutil` import from book router

## Testing
- `ruff check backend/app/routers/books.py`
- `PYTHONPATH=/workspace/Storyboard pytest -q` *(fails: book endpoints and parser tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b7cf5804832f976da1b5c2e2316e